### PR TITLE
prefer system spicyz (fix for Zeek v5) and don't unset C++ toolchain variables

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -3,8 +3,8 @@ summary = A Zeek OpenVPN protocol analyzer, based on Spicy.
 description = A Zeek OpenVPN protocol analyzer, based on Spicy.
 script_dir = analyzer
 plugin_dir = build/spicy-modules
-build_command = unset -v CXX CXXFLAGS LD LDFLAGS && mkdir -p build && cd build && SPICYZ=%(package_base)s/spicy-plugin/build/bin/spicyz cmake .. && cmake --build .
-test_command = unset -v CXX CXXFLAGS LD LDFLAGS && cd tests && PATH=$(zkg config plugin_dir)/packages/spicy-plugin/bin:$PATH btest -d -j $(nproc)
+build_command = mkdir -p build && cd build && SPICYZ=$(command -v spicyz || echo %(package_base)s/spicy-plugin/build/bin/spicyz) cmake .. && cmake --build .
+test_command = cd tests && PATH=$(zkg config plugin_dir)/packages/spicy-plugin/bin:$PATH btest -d -j $(nproc)
 
 [template]
 source = package-template-spicy


### PR DESCRIPTION
build_command should check for system spicyz before falling back to spicy-plugin/build/bin/spicyz (allows plugin to work with Zeek v5.0.0's built-in spicy plugin, see https://github.com/zeek/spicy-ldap/blob/06690d5f82598b127a491314e314a6d17d1ca082/zkg.meta#L6=); and, allow customization of C++ toolchain via canonical environment variables (see https://github.com/zeek/spicy-ldap/commit/06690d5f82598b127a491314e314a6d17d1ca082)

Tested install with Zeek v5.0.0 (with integrated spicy) and Zeek v4.2.2 (with spicy deb and zkg-installed zeek spicy-plugin).

Signed-off-by: Seth Grover <mero.mero.guero@gmail.com>