### PR TITLE
v6.1 will depreciate analyzer_confirmation()

### DIFF
--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -97,7 +97,11 @@ function set_session(c: connection)
 		c$openvpn = [];
 	}
 
+@if (version::at_least("6.0.0"))
+event analyzer_confirmation_info(atype: AllAnalyzers::Tag, info: AnalyzerConfirmationInfo) &priority=5
+@else
 event analyzer_confirmation(c: connection, atype: Analyzer::Tag, aid: count) &priority=5
+@endif
 	{
 	if ( atype == Analyzer::ANALYZER_SPICY_OPENVPN_UDP ||
 		 atype == Analyzer::ANALYZER_SPICY_OPENVPN_UDP_HMAC_MD5 ||
@@ -110,8 +114,13 @@ event analyzer_confirmation(c: connection, atype: Analyzer::Tag, aid: count) &pr
 		 atype == Analyzer::ANALYZER_SPICY_OPENVPN_TCP_HMAC_SHA256 ||
 		 atype == Analyzer::ANALYZER_SPICY_OPENVPN_TCP_HMAC_SHA512 )
 		{
+@if (version::at_least("6.0.0"))
+		set_session(info$c);
+		info$c$openvpn$analyzer_id = info$aid;
+@else
 		set_session(c);
 		c$openvpn$analyzer_id = aid;
+@endif
 		}
 	}
 


### PR DESCRIPTION
Could maybe also use version >= 5.3.