### PR TITLE
Zeek 7.1 compatibility changes

### DIFF
--- a/tests/analyzer/openvpn.zeek
+++ b/tests/analyzer/openvpn.zeek
@@ -1,5 +1,5 @@
 # @TEST-EXEC: zeek -C -r ${TRACES}/openvpn.pcap %INPUT >openvpn.out
-# @TEST-EXEC: cat conn.log | zeek-cut -m -n local_orig local_resp >conn.log.filtered
+# @TEST-EXEC: zeek-cut -m -n local_orig local_resp ip_proto < conn.log > conn.log.filtered
 # @TEST-EXEC: btest-diff openvpn.out
 # @TEST-EXEC: btest-diff conn.log.filtered
 # @TEST-EXEC: btest-diff ssl.log

--- a/tests/analyzer/openvpnhmac.zeek
+++ b/tests/analyzer/openvpnhmac.zeek
@@ -1,5 +1,5 @@
 # @TEST-EXEC: zeek -C -r ${TRACES}/openvpn_udp_tls-auth.pcap %INPUT >openvpn.out
-# @TEST-EXEC: cat conn.log | zeek-cut -m -n local_orig local_resp >conn.log.filtered
+# @TEST-EXEC: zeek-cut -m -n local_orig local_resp ip_proto < conn.log > conn.log.filtered
 # @TEST-EXEC: btest-diff openvpn.out
 # @TEST-EXEC: btest-diff conn.log.filtered
 # @TEST-EXEC: btest-diff ssl.log

--- a/tests/analyzer/openvpnhmac256.zeek
+++ b/tests/analyzer/openvpnhmac256.zeek
@@ -1,5 +1,5 @@
 # @TEST-EXEC: zeek -C -r ${TRACES}/openvpn_udp_hmac_256.pcap %INPUT >openvpn.out
-# @TEST-EXEC: cat conn.log | zeek-cut -m -n local_orig local_resp >conn.log.filtered
+# @TEST-EXEC: zeek-cut -m -n local_orig local_resp ip_proto < conn.log > conn.log.filtered
 # @TEST-EXEC: btest-diff openvpn.out
 # @TEST-EXEC: btest-diff conn.log.filtered
 # @TEST-EXEC: btest-diff ssl.log

--- a/tests/analyzer/openvpntcp.zeek
+++ b/tests/analyzer/openvpntcp.zeek
@@ -1,5 +1,5 @@
 # @TEST-EXEC: zeek -C -r ${TRACES}/openvpn_tcp_nontlsauth.pcap %INPUT >openvpn.out
-# @TEST-EXEC: cat conn.log | zeek-cut -m -n local_orig local_resp >conn.log.filtered
+# @TEST-EXEC: zeek-cut -m -n local_orig local_resp ip_proto < conn.log > conn.log.filtered
 # @TEST-EXEC: btest-diff openvpn.out
 # @TEST-EXEC: btest-diff conn.log.filtered
 # @TEST-EXEC: btest-diff ssl.log

--- a/tests/analyzer/openvpntcphmac.zeek
+++ b/tests/analyzer/openvpntcphmac.zeek
@@ -1,5 +1,5 @@
 # @TEST-EXEC: zeek -C -r ${TRACES}/openvpn-tcp-tls-auth.pcap %INPUT >openvpn.out
-# @TEST-EXEC: cat conn.log | zeek-cut -m -n local_orig local_resp >conn.log.filtered
+# @TEST-EXEC: zeek-cut -m -n local_orig local_resp ip_proto < conn.log > conn.log.filtered
 # @TEST-EXEC: btest-diff openvpn.out
 # @TEST-EXEC: btest-diff conn.log.filtered
 # @TEST-EXEC: btest-diff ssl.log


### PR DESCRIPTION
Zeek 7.1 introduced the 'ip_proto' field in the conn.log. To maintain consistent baselines across Zeek 7 versions, cut the ip_proto field in affected btests.